### PR TITLE
Set build target to node12

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -10,6 +10,7 @@ custom:
   esbuild:
     bundle: true
     minify: true
+    target: node12
   s3:
     port: 8888
     directory: /app/.s3-local


### PR DESCRIPTION
Set build target to node12, since AWS SDK uses async generator functions, which are not supported by esbuild for targets below es2018 (default was es2017)