### PR TITLE
Commented out local dynamodb plugin in serverless.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ run `sls-invoke initialiseToken --stage dev`.
 
 #### DynamoDB ####
 
-If you want to use DynamoDB offline, you'll need to run `serverless dynamodb install` in your project once, to
+If you want to use DynamoDB offline, uncomment the line `- serverless-dynamodb-local` in serverless.yml. You'll need to run `serverless dynamodb install` in your project once, to
 download the local dynamodb code.
 
 #### SSM Parameters ####

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,7 +27,7 @@ custom:
 
 plugins:
   - serverless-s3-local
-  - serverless-dynamodb-local
+  # - serverless-dynamodb-local # local dynamoDB requires running `serverless dynamodb install`
   - serverless-offline-ssm
   - serverless-offline
   - serverless-esbuild


### PR DESCRIPTION
Running docker-compose up with the dynamodb-local plugin gives a cryptic error if the dynamodb libraries haven't been installed yet.

Either the readme should include this as a required step or that plugin should not be active by default. I've chosen the latter as not all services will need dynamodb.