### PR TITLE
Adding a local snippets file for to put common boilerplate handler code

### DIFF
--- a/.vscode/serverless.code-snippets
+++ b/.vscode/serverless.code-snippets
@@ -1,0 +1,35 @@
+{
+	// Place your localstack-step-functions workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
+	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+	// Placeholders with the same ids are connected.
+	// Example:
+	// "Print to console": {
+	// 	"scope": "javascript,typescript",
+	// 	"prefix": "log",
+	// 	"body": [
+	// 		"console.log('$1');",
+	// 		"$2"
+	// 	],
+	// 	"description": "Log output to console"
+	// }
+  "Create a new API Gateway handler": {
+    "prefix": "apigateway",
+    "body": [
+      "import { APIGatewayEventRequestContext, APIGatewayProxyEvent, APIGatewayProxyResult } from \"aws-lambda\";",
+      "",
+      "",
+      "export const handler = async (event: APIGatewayProxyEvent, _context: APIGatewayEventRequestContext): Promise<APIGatewayProxyResult> => {",
+      "  const response: APIGatewayProxyResult = {",
+      "    statusCode: 200,",
+      "    body: `Successfully returned response from GET method`",
+      "  };",
+      "",
+      "  return response;",
+      "};"
+    ],
+    "description": "Create a new API Gateway handler"
+  }
+}


### PR DESCRIPTION
Not 100% necessary but a standard snippets file could help onboard people and speed up development a bit.