### PR TITLE
add esModuleInterop option to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "lib": ["es2019"],
     "removeComments": true,
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "sourceMap": true,


### PR DESCRIPTION
This option fixes some problems with CommonJS modules: https://www.typescriptlang.org/tsconfig#esModuleInterop

We can use `require` syntax instead but the consistency of import is nice.