### PR TITLE
Add 'noImplicitAny' option to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2019"],
+    "noImplicitAny": true,
     "removeComments": true,
     "moduleResolution": "node",
     "noUnusedLocals": true,


### PR DESCRIPTION
Allowing implicit 'any' types can cause the typing system to ignore incorrect or risky property and index references. Devs can still explicitly assign the 'any' type where that looseness is appropriate.

https://www.typescriptlang.org/tsconfig#noImplicitAny