### PR TITLE
--conceal option added to pipeline deploy command

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -15,4 +15,4 @@ pipelines:
             - | 
               [[ "$BITBUCKET_BRANCH" == "production" ]] && stage="production" || stage="staging"
               echo "Deploying to $stage..."
-            - /serverless/node_modules/serverless/bin/serverless.js deploy --stage $stage --aws-profile bitbucket-deployer
+            - /serverless/node_modules/serverless/bin/serverless.js deploy --stage $stage --aws-profile bitbucket-deployer --conceal


### PR DESCRIPTION
This option prevents serverless from printing the value of API keys in the pipeline output on successful deploy of private APIGateway endpoints.

The API keys can be accessed from the AWS console.