### PR TITLE
Adds CloudFormation service role parameter to template

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: SERVICE_NAME # To be replaced
+service: example-service-name # To be replaced
 
 configValidationMode: error
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: <SERVICE_NAME>
+service: SERVICE_NAME # To be replaced
 
 configValidationMode: error
 
@@ -28,7 +28,7 @@ plugins:
 
 provider:
   name: aws
-  cfnRole: <ARN_OF_CLOUDFORMATION_SERVICE_ROLE>
+  cfnRole: ARN_OF_CLOUDFORMATION_SERVICE_ROLE # To be replaced
   runtime: nodejs12.x
   stage: ${opt:stage, 'dev'}
   region: ${opt:region, 'ap-southeast-2'}

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,7 +28,10 @@ plugins:
 
 provider:
   name: aws
-  cfnRole: ARN_OF_CLOUDFORMATION_SERVICE_ROLE # To be replaced
+  # It is a good security practice to use a CloudFormation service
+  # role for performing deployments.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html
+  # cfnRole: ARN_OF_CLOUDFORMATION_SERVICE_ROLE # To be replaced
   runtime: nodejs12.x
   stage: ${opt:stage, 'dev'}
   region: ${opt:region, 'ap-southeast-2'}

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,6 +28,7 @@ plugins:
 
 provider:
   name: aws
+  cfnRole: <ARN_OF_CLOUDFORMATION_SERVICE_ROLE>
   runtime: nodejs12.x
   stage: ${opt:stage, 'dev'}
   region: ${opt:region, 'ap-southeast-2'}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: local-stack-template # NOTE: update this with your service name
+service: <SERVICE_NAME>
 
 configValidationMode: error
 


### PR DESCRIPTION
Adds [CloudFormation service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html) parameter to template.
To encourage security best practices I believe the default should be to deploy using a CloudFormation service role as opposed to deploying using the IAM privileges of the deploy context.