### PR TITLE
Add code coverage flag to test step

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "deploy-local": "docker-compose exec -u node -w /app offline /serverless/node_modules/serverless/bin/serverless.js deploy --log --profile localstack --stage dev",
     "invoke-local": "docker-compose exec -u node -w /app offline /serverless/node_modules/serverless/bin/serverless.js invoke --log --profile localstack --stage dev --function ",
     "invoke-local-stepf": "docker-compose exec -u node -w /app offline /serverless/node_modules/serverless/bin/serverless.js invoke stepf --log --profile localstack --stage dev --name ",
-    "test": "jest",
+    "test": "jest --coverage",
     "lint": "eslint . --ext .ts"
   },
   "dependencies": {


### PR DESCRIPTION
Adds the NPM `--coverage` flag to NPM test step.

This will output a pretty coverage report.