### PR TITLE
Add test coverage thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ vscode
 
 # Localstack directories
 .localstack
+
+# Jest coverage output
+converage

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,13 @@ module.exports = {
         'ts-jest': {
             isolatedModules: true
         }
-    }
+    },
+     "coverageThreshold": {
+          "global": {
+               "branches": 80,
+               "functions": 80,
+               "lines": 80,
+               "statements": 80
+          }
+     }
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,12 +6,12 @@ module.exports = {
             isolatedModules: true
         }
     },
-     "coverageThreshold": {
-          "global": {
-               "branches": 80,
-               "functions": 80,
-               "lines": 80,
-               "statements": 80
-          }
-     }
+    coverageThreshold: {
+         global: {
+              branches: 80,
+              functions: 80,
+              lines: 80,
+              statements: 80
+         }
+    }
 };


### PR DESCRIPTION
Add [Jest coverage thresholds](https://jestjs.io/docs/configuration) of 80% to branches, functions, lines and statements.

I think 80% is a good default. If projects chose to remove / lower this at least it is intentional.