### PR TITLE
Upgrade to use AWS node 14 runtime

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -10,7 +10,7 @@ custom:
   esbuild:
     bundle: true
     minify: true
-    target: node12
+    target: node14
   localstack:
     debug: true
     autostart: false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["es2019"],
+    "lib": ["ES2019"],
     "noImplicitAny": true,
     "removeComments": true,
     "moduleResolution": "node",
@@ -8,7 +8,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "sourceMap": true,
-    "target": "es2017",
+    "target": "ES2019",
     "outDir": "lib",
     "typeRoots": ["./types", "./node_modules/@types"]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2019"],
+    "lib": ["ES2020"],
     "noImplicitAny": true,
     "removeComments": true,
     "moduleResolution": "node",
@@ -8,7 +8,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "sourceMap": true,
-    "target": "ES2019",
+    "target": "ES2020",
     "outDir": "lib",
     "typeRoots": ["./types", "./node_modules/@types"]
   },
@@ -25,3 +25,4 @@
     "types"
   ]
 }
+


### PR DESCRIPTION
AWS supports node 14 (https://aws.amazon.com/blogs/compute/node-js-14-x-runtime-now-available-in-aws-lambda/) so update the template to reflect that.

Also tweaked the tsconfig to match recommended settings (https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)