### PR TITLE
Added the conventions plugin to serverless.yml

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -25,6 +25,7 @@ plugins:
   - serverless-esbuild
   - serverless-localstack
   - serverless-step-functions
+  - "@aligent/serverless-conventions"
 
 provider:
   name: aws


### PR DESCRIPTION
Because I only added it to the package.json and didn't actually add it to the serverless.yml file for some reason. (PR #285 )