### PR TITLE
"Failing test" should not be a passing test

### DIFF
--- a/tests/example-tests.test.ts
+++ b/tests/example-tests.test.ts
@@ -5,8 +5,8 @@ describe('Passing tests', () => {
         expect(1).toBeTruthy();
     });
 
-    test('Failing test', () => {
-        expect(1).toBeGreaterThan(0);
+    test.skip('Skipped/Failing test', () => {
+        expect(-1).toBeGreaterThan(0);
     });
 });
 


### PR DESCRIPTION
The example test called "failing test" should actually fail when run - it's misleading otherwise.

We can skip the test to prevent an error (and show that this is possible in Jest).