### PR TITLE
Remove CloudFormation service role

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aligent/serverless-conventions": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@aligent/serverless-conventions/-/serverless-conventions-0.1.1.tgz",
-      "integrity": "sha512-imltR66B1txhWZL8qtM6abcR/hjsRavfTxjt/qTqCUClX7hxVkFnWhHLzgLL0mjJ1dmtMeOYiuxZFmsuBUrB0A==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@aligent/serverless-conventions/-/serverless-conventions-0.2.1.tgz",
+      "integrity": "sha512-eGK85HOSBfcGJQWL2Y/C7hPHXCIj9JgaosP/5bVADKZjzzDvw3bgkP9qUI77NKtDiR3YLLL6P6gYfrX8R+3C+w==",
       "requires": {
         "chalk": "^4.1.1",
         "change-case": "^4.1.2"

--- a/serverless.yml
+++ b/serverless.yml
@@ -29,11 +29,6 @@ plugins:
 
 provider:
   name: aws
-  # It is a good security practice to use a CloudFormation service
-  # role for performing deployments.
-  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html
-  iam:
-    deploymentRole: arn:aws:iam::123456789000:role/example.serverless # To be replaced
   runtime: nodejs14.x
   stage: ${opt:stage, 'dev'}
   region: ${opt:region, 'ap-southeast-2'}


### PR DESCRIPTION
This PR removes the CFN deployment role from the template.

This is no longer necessary as our pipelines can inject this at deploy time.

[Related PR](https://github.com/aligent/serverless-deploy-pipe/pull/2).