### PR TITLE
DO-1270: Adds cfn role to bitbucket pipeline

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -15,6 +15,7 @@ definitions:
             variables:
               AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
               AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+              CFN_ROLE: ${CFN_ROLE}
               DEBUG: ${CI_DEBUG}
 
 pipelines:


### PR DESCRIPTION
The serverless deploy pipe has been updated to inject the cfn role during deployment. This updates the bitbucket-pipeline.yml to pass a cfn role variable.