### PR TITLE
Increase docker memory to 3GB

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,6 +1,9 @@
 image: aligent/serverless
 
 definitions:
+  services:
+    docker:
+      memory: 3072
   steps:
     - step: &test
         name: Test


### PR DESCRIPTION
With the deploy pipe updated to Node 16, deployments are running out of memory during npm ci.