### PR TITLE
MICRO-50: Support step through debug with VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-azuretools.vscode-docker"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
             "preLaunchTask": "sls-docker: debug-test"
         },
         {
-            "name": "Invoke Local Debug",
+            "name": "Debug Invoke Local Json Path",
             "type": "node",
             "request": "attach",
             "address": "localhost",
@@ -32,7 +32,22 @@
                 "${workspaceFolder}/.esbuild/**/*.js"
             ],
             "internalConsoleOptions": "neverOpen",
-            "preLaunchTask": "sls-docker: debug-invoke-local"
+            "preLaunchTask": "sls-docker: debug-invoke-local-path"
+        },
+        {
+            "name": "Debug Invoke Local String Data",
+            "type": "node",
+            "request": "attach",
+            "address": "localhost",
+            "port": 9229,
+            "sourceMaps": true,
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "/app",
+            "outFiles": [
+                "${workspaceFolder}/.esbuild/**/*.js"
+            ],
+            "internalConsoleOptions": "neverOpen",
+            "preLaunchTask": "sls-docker: debug-invoke-local-data"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug with Jest Test",
+            "type": "node",
+            "request": "attach",
+            "address": "localhost",
+            "port": 9229,
+            "sourceMaps": true,
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "/app",
+            "outFiles": [
+                "${workspaceFolder}/.esbuild/**/*.js"
+            ],
+            "internalConsoleOptions": "neverOpen",
+            "preLaunchTask": "sls-docker: debug-test"
+        },
+        {
+            "name": "Invoke Local Debug",
+            "type": "node",
+            "request": "attach",
+            "address": "localhost",
+            "port": 9229,
+            "sourceMaps": true,
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "/app",
+            "outFiles": [
+                "${workspaceFolder}/.esbuild/**/*.js"
+            ],
+            "internalConsoleOptions": "neverOpen",
+            "preLaunchTask": "sls-docker: debug-invoke-local"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -133,7 +133,7 @@
                 "close": true
             },
             "dependsOn": [
-                "sls-docker: remove-old-containers"
+                "sls-docker: debug-package"
             ]
         },
         // Invoke local lambda function with debug enabled with data file
@@ -185,6 +185,52 @@
                 "close": true
             },
             "dependsOn": [
+                "sls-docker: debug-package"
+            ]
+        },
+        // Package for debugging
+        {
+            "type": "docker-run",
+            "label": "sls-docker: debug-package",
+            "icon": {
+                "color": "terminal.ansiYellow",
+                "id": "debug-alt"
+            },
+            "dockerRun": {
+                "image": "aligent/serverless:latest",
+                "containerName": "vsdebug-package",
+                "portsPublishAll": false,
+                "volumes": [
+                    {
+                        "localPath": "${userHome}/.aws",
+                        "containerPath": "/home/node/.aws"
+                    },
+                    {
+                        "localPath": "${userHome}/.azure",
+                        "containerPath": "/home/node/.azure"
+                    },
+                    {
+                        "localPath": "${userHome}/.npm",
+                        "containerPath": "/home/node/.npm"
+                    },
+                    {
+                        "localPath": "${workspaceFolder}",
+                        "containerPath": "/app"
+                    }
+                ],
+                "command": "npm run debug-package"
+            },
+            "problemMatcher": [],
+            "presentation": {
+                "echo": false,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true,
+                "close": true
+            },
+            "dependsOn": [
                 "sls-docker: remove-old-containers"
             ]
         },
@@ -206,9 +252,9 @@
             ],
             "problemMatcher": [],
             "presentation": {
-                "echo": true,
+                "echo": false,
                 "reveal": "always",
-                "focus": true,
+                "focus": false,
                 "panel": "shared",
                 "showReuseMessage": true,
                 "clear": true,
@@ -236,9 +282,9 @@
             ],
             "problemMatcher": [],
             "presentation": {
-                "echo": true,
+                "echo": false,
                 "reveal": "always",
-                "focus": true,
+                "focus": false,
                 "panel": "shared",
                 "showReuseMessage": true,
                 "clear": true,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "id": "functionName",
             "type": "promptString",
             "default": "hello",
-            "description": "I am invoking local function: "
+            "description": "Enter the function logical name as shown in `serverless.yml`: "
         },
         {
             "id": "specName",
@@ -26,7 +26,7 @@
             // NOTE: Do not add / at the beginning of the input
             "id": "dataFile",
             "type": "promptString",
-            "default": "debug/dev.invoke.json",
+            "default": "debug-local-invoke.json",
             "description": "Please use the data from this file: "
         }
     ],
@@ -41,8 +41,7 @@
             },
             "dockerRun": {
                 "image": "aligent/serverless:latest",
-                "containerName": "debug-test",
-                "remove": true,
+                "containerName": "vsdebug-test",
                 "portsPublishAll": false,
                 "ports": [
                     {
@@ -79,21 +78,23 @@
                 "showReuseMessage": true,
                 "clear": true,
                 "close": true
-            }
+            },
+            "dependsOn": [
+                "sls-docker: remove-old-containers"
+            ]
         },
-        // Invoke local lambda function with debug enabled
+        // Invoke local lambda function with debug enabled with string data
         // Note: First run will always fails because the IDE needs to bind with source map which is not available yet
         {
             "type": "docker-run",
-            "label": "sls-docker: debug-invoke-local",
+            "label": "sls-docker: debug-invoke-local-data",
             "icon": {
                 "color": "terminal.ansiYellow",
                 "id": "debug-alt"
             },
             "dockerRun": {
                 "image": "aligent/serverless:latest",
-                "containerName": "debug-invoke-local",
-                "remove": true,
+                "containerName": "vsdebug-invoke-local",
                 "portsPublishAll": false,
                 "ports": [
                     {
@@ -126,6 +127,118 @@
                 "echo": true,
                 "reveal": "always",
                 "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true,
+                "close": true
+            },
+            "dependsOn": [
+                "sls-docker: remove-old-containers"
+            ]
+        },
+        // Invoke local lambda function with debug enabled with data file
+        {
+            "type": "docker-run",
+            "label": "sls-docker: debug-invoke-local-path",
+            "icon": {
+                "color": "terminal.ansiYellow",
+                "id": "debug-alt"
+            },
+            "dockerRun": {
+                "image": "aligent/serverless:latest",
+                "containerName": "vsdebug-invoke-local",
+                "portsPublishAll": false,
+                "ports": [
+                    {
+                        "containerPort": 9229,
+                        "hostPort": 9229
+                    }
+                ],
+                "volumes": [
+                    {
+                        "localPath": "${userHome}/.aws",
+                        "containerPath": "/home/node/.aws"
+                    },
+                    {
+                        "localPath": "${userHome}/.azure",
+                        "containerPath": "/home/node/.azure"
+                    },
+                    {
+                        "localPath": "${userHome}/.npm",
+                        "containerPath": "/home/node/.npm"
+                    },
+                    {
+                        "localPath": "${workspaceFolder}",
+                        "containerPath": "/app"
+                    }
+                ],
+                "command": "npm run debug-invoke-local -- -f ${input:functionName} -p ${input:dataFile}"
+            },
+            "problemMatcher": [],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true,
+                "close": true
+            },
+            "dependsOn": [
+                "sls-docker: remove-old-containers"
+            ]
+        },
+        // Remove old containters
+        {
+            "type": "shell",
+            "label": "sls-docker: remove-old-containers",
+            "icon": {
+                "color": "terminal.ansiGreen",
+                "id": "package"
+            },
+            "hide": true,
+            "command": [
+                "[[ -z \"$(docker container ls -qa --filter name=vsdebug-)\" ]]",
+                "&&",
+                "echo Nothing to remove",
+                "||",
+                "docker container rm $(docker container ls -qa --filter name=vsdebug-)"
+            ],
+            "problemMatcher": [],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true,
+                "close": true
+            },
+            "dependsOn": [
+                "sls-docker: stop-old-containers"
+            ]
+        },
+        // Stop old containters if any of them are still running
+        {
+            "type": "shell",
+            "label": "sls-docker: stop-old-containers",
+            "icon": {
+                "color": "terminal.ansiGreen",
+                "id": "package"
+            },
+            "hide": true,
+            "command": [
+                "[[ -z \"$(docker container ls -q --filter name=vsdebug- --filter status=running)\" ]]",
+                "&&",
+                "echo Nothing is running",
+                "||",
+                "docker container stop $(docker container ls -q --filter name=vsdebug- --filter status=running)",
+            ],
+            "problemMatcher": [],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
                 "panel": "shared",
                 "showReuseMessage": true,
                 "clear": true,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,168 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "inputs": [
+        {
+            "id": "functionName",
+            "type": "promptString",
+            "default": "hello",
+            "description": "I am invoking local function: "
+        },
+        {
+            "id": "specName",
+            "type": "promptString",
+            "default": "name-of-spec",
+            "description": "I am debugging test case: "
+        },
+        {
+            "id": "payloadData",
+            "type": "promptString",
+            "default": "'{\"foo\":\"bar\"}'",
+            "description": "Please use this payload data: "
+        },
+        {
+            // This must be inside our workspace folder as we only mount bind $pwd:/app
+            // NOTE: Do not add / at the beginning of the input
+            "id": "dataFile",
+            "type": "promptString",
+            "default": "debug/dev.invoke.json",
+            "description": "Please use the data from this file: "
+        }
+    ],
+    "tasks": [
+        // Run a Jest test with debug enabled
+        {
+            "type": "docker-run",
+            "label": "sls-docker: debug-test",
+            "icon": {
+                "color": "terminal.ansiYellow",
+                "id": "beaker"
+            },
+            "dockerRun": {
+                "image": "aligent/serverless:debug",
+                "containerName": "debug-test",
+                "remove": true,
+                "portsPublishAll": false,
+                "ports": [
+                    {
+                        "containerPort": 9229,
+                        "hostPort": 9229
+                    }
+                ],
+                "volumes": [
+                    {
+                        "localPath": "${userHome}/.aws",
+                        "containerPath": "/home/node/.aws"
+                    },
+                    {
+                        "localPath": "${userHome}/.azure",
+                        "containerPath": "/home/node/.azure"
+                    },
+                    {
+                        "localPath": "${userHome}/.npm",
+                        "containerPath": "/home/node/.npm"
+                    },
+                    {
+                        "localPath": "${workspaceFolder}",
+                        "containerPath": "/app"
+                    }
+                ],
+                "command": "npm run debug-test -- -t \"${input:specName}\""
+            },
+            "dependsOn": [
+                "sls-docker: build-serverless-debug"
+            ],
+            "problemMatcher": [],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true,
+                "close": true
+            }
+        },
+        // Invoke local lambda function with debug enabled
+        // Note: First run will always fails because the IDE needs to bind with source map which is not available yet
+        {
+            "type": "docker-run",
+            "label": "sls-docker: debug-invoke-local",
+            "icon": {
+                "color": "terminal.ansiYellow",
+                "id": "debug-alt"
+            },
+            "dockerRun": {
+                "image": "aligent/serverless:debug",
+                "containerName": "debug-invoke-local",
+                "remove": true,
+                "portsPublishAll": false,
+                "ports": [
+                    {
+                        "containerPort": 9229,
+                        "hostPort": 9229
+                    }
+                ],
+                "volumes": [
+                    {
+                        "localPath": "${userHome}/.aws",
+                        "containerPath": "/home/node/.aws"
+                    },
+                    {
+                        "localPath": "${userHome}/.azure",
+                        "containerPath": "/home/node/.azure"
+                    },
+                    {
+                        "localPath": "${userHome}/.npm",
+                        "containerPath": "/home/node/.npm"
+                    },
+                    {
+                        "localPath": "${workspaceFolder}",
+                        "containerPath": "/app"
+                    }
+                ],
+                "command": "npm run debug-invoke-local -- -f ${input:functionName} -d ${input:payloadData}"
+            },
+            "dependsOn": [
+                "sls-docker: build-serverless-debug"
+            ],
+            "problemMatcher": [],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true,
+                "close": true
+            }
+        },
+        // Build aligent/serverless:debug image if it does not exist
+        // This is hidden because it will be run automatically when needed.
+        {
+            "type": "shell",
+            "label": "sls-docker: build-serverless-debug",
+            "icon": {
+                "color": "terminal.ansiGreen",
+                "id": "package"
+            },
+            "hide": true,
+            "command": [
+                "[[ -n \"$(docker images -q aligent/serverless:debug)\" ]]",
+                "||",
+                "docker build . -t aligent/serverless:debug"
+            ],
+            "problemMatcher": [],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true,
+                "close": true
+            }
+        },
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -40,7 +40,7 @@
                 "id": "beaker"
             },
             "dockerRun": {
-                "image": "aligent/serverless:debug",
+                "image": "aligent/serverless:latest",
                 "containerName": "debug-test",
                 "remove": true,
                 "portsPublishAll": false,
@@ -70,9 +70,6 @@
                 ],
                 "command": "npm run debug-test -- -t \"${input:specName}\""
             },
-            "dependsOn": [
-                "sls-docker: build-serverless-debug"
-            ],
             "problemMatcher": [],
             "presentation": {
                 "echo": true,
@@ -94,7 +91,7 @@
                 "id": "debug-alt"
             },
             "dockerRun": {
-                "image": "aligent/serverless:debug",
+                "image": "aligent/serverless:latest",
                 "containerName": "debug-invoke-local",
                 "remove": true,
                 "portsPublishAll": false,
@@ -124,9 +121,6 @@
                 ],
                 "command": "npm run debug-invoke-local -- -f ${input:functionName} -d ${input:payloadData}"
             },
-            "dependsOn": [
-                "sls-docker: build-serverless-debug"
-            ],
             "problemMatcher": [],
             "presentation": {
                 "echo": true,
@@ -137,32 +131,6 @@
                 "clear": true,
                 "close": true
             }
-        },
-        // Build aligent/serverless:debug image if it does not exist
-        // This is hidden because it will be run automatically when needed.
-        {
-            "type": "shell",
-            "label": "sls-docker: build-serverless-debug",
-            "icon": {
-                "color": "terminal.ansiGreen",
-                "id": "package"
-            },
-            "hide": true,
-            "command": [
-                "[[ -n \"$(docker images -q aligent/serverless:debug)\" ]]",
-                "||",
-                "docker build . -t aligent/serverless:debug"
-            ],
-            "problemMatcher": [],
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": true,
-                "clear": true,
-                "close": true
-            }
-        },
+        }
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM aligent/serverless:latest
+
+EXPOSE 9229

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM aligent/serverless:latest
-
-EXPOSE 9229

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Serverless ESBuild example using Typescript",
   "main": "handler.js",
   "scripts": {
+    "debug-test": "node --inspect=0.0.0.0 ./node_modules/.bin/jest --runInBand",
+    "debug-invoke-local": "MINIFY=false SOURCEMAP=true node --inspect=0.0.0.0 ./node_modules/.bin/serverless invoke local",
     "test": "jest --coverage",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write ."

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "debug-test": "node --inspect=0.0.0.0 ./node_modules/.bin/jest --runInBand",
     "debug-invoke-local": "MINIFY=false SOURCEMAP=true node --inspect=0.0.0.0 ./node_modules/.bin/serverless invoke local",
+    "debug-package": "MINIFY=false SOURCEMAP=true KEEP_OUTPUT=true node ./node_modules/.bin/serverless package",
     "test": "jest --coverage",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write ."

--- a/serverless.yml
+++ b/serverless.yml
@@ -11,6 +11,7 @@ custom:
     bundle: true
     minify: ${strToBool(${env:MINIFY, 'true'})}
     sourcemap: ${strToBool(${env:SOURCEMAP, 'false'})}
+    keepOutputDirectory: ${strToBool(${env:KEEP_OUTPUT, 'false'})}
     target: node16
 
 plugins:

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,7 +9,8 @@ package:
 custom:
   esbuild:
     bundle: true
-    minify: true
+    minify: ${strToBool(${env:MINIFY, 'true'})}
+    sourcemap: ${strToBool(${env:SOURCEMAP, 'false'})}
     target: node16
 
 plugins:


### PR DESCRIPTION
This PR aims to add the ability to debug lambda function with VSCode. There are couple of notes as listed below:

- This approach leverage the [VSCode Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) to build and run our `aligent/serverless:debug` docker container for debugging purpose.
- Enable `sourcemap` and disable `minify` through environment variable when building with `esbuild` to support debugging by `invoke local`.
- There is a caveat while using `invoke local` to debug. After a code change, the first time we try to debug with `invoke local`, VSCode will fail to attach to the debugger. This happens because `serverless` will not build our code until we trigger that invocation. All the sub sequence launches will success and we will be able to attach to the debugger normally.