### PR TITLE
Add stage to state machine name

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -44,7 +44,7 @@ stepFunctions:
   validate: true
   stateMachines:
     helloWorld:
-      name: ${self:service}-helloWorld
+      name: ${self:service}-${self:provider.stage}-helloWorld
       definition:
         StartAt: Hello
         States:


### PR DESCRIPTION
This PR address an issue of duplicated state machine name.
When I tried to deploy this template with different stages cli param to playground (`dev` vs. `stg` for example), Serverless then failed to deploy at the second time because it found an existing state machine with the same name.

Steps to repro this issue:

1. Deploy to playground with command: `serverless deploy -s dev`
2. Deploy to playground with command: `serverless deploy -s stg`
3. Notice that the second deployment is failed while it suppose to be success.