### PR TITLE
Replace npm install with npm ci in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then install dependencies:
 
 `cd my-project`
 
-`node-run npm install`.
+`node-run npm ci`.
 
 ### Local NPM
 
@@ -46,7 +46,7 @@ Then install dependencies:
 
 `cd my-project`
 
-`node-run npm install`.
+`node-run npm ci`.
 
 ## Development Environment
 


### PR DESCRIPTION
If we're including package-lock.json in the template we should suggest using `ci` to install dependencies