### PR TITLE
fix: add space in codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*@tvhees @aligent/aligent-devops
+* @tvhees @aligent/aligent-devops


### PR DESCRIPTION
The codeowners file was invalid. With this change we should start correctly being auto-assigned PRs.