### PR TITLE
Add eslint configuration to disallow return await

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,18 @@
 {
     "root": true,
     "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "project": ["./tsconfig.json"]
+    },
     "plugins": ["@typescript-eslint"],
     "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/eslint-recommended",
         "plugin:@typescript-eslint/recommended",
         "prettier"
-    ]
+    ],
+    "rules": {
+        "no-return-await": "off",
+        "@typescript-eslint/return-await": "error"
+    }
 }


### PR DESCRIPTION
Awaiting a promise before returning in the same statement is usually redundant inside async functions. This lint rule will tell developers when they can remove the await keyword.

return await will still be allowed inside try/catch blocks where it is necessary for error handling to behave as expected.

Rule documentation: https://typescript-eslint.io/rules/return-await/