### PR TITLE
Replace Globals/preset spec with transform syntax

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+jest.config.js

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,12 @@
 module.exports = {
-    preset: 'ts-jest',
     testEnvironment: 'node',
-    globals: {
-        'ts-jest': {
-            isolatedModules: true,
-        },
+    transform: {
+        '^.+\\.m?[tj]sx?$': [
+            'ts-jest',
+            {
+                isolatedModules: true,
+            },
+        ],
     },
     coverageThreshold: {
         global: {


### PR DESCRIPTION
ts-jest started giving warnings about deprecated syntax in jest configuration. This PR implements the suggested new syntax.

Also ignoring jest config in eslint as it otherwise gives a warning about not being included in tsconfig spec