### PR TITLE
#596 remove `main` entry from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "base",
   "version": "1.0.0",
   "description": "Serverless ESBuild example using Typescript",
-  "main": "handler.js",
   "scripts": {
     "test": "jest --coverage",
     "lint": "eslint . --ext .ts",


### PR DESCRIPTION
An entry point doesn't really make sense here, and handler.js doesn't exist.