### PR TITLE
feat: add stage to bitbucket pipeline

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -23,6 +23,7 @@ definitions:
               UPLOAD_BADGE: 'true'
               APP_USERNAME: ${APP_USERNAME}
               APP_PASSWORD: ${APP_PASSWORD}
+              STAGE: ${STAGE}
 pipelines:
   pull-requests:
     '**':


### PR DESCRIPTION
Currently serverless conventions will fail during a pipeline run as it defaults to using the branch name as the stage. `staging` is not a valid stage name as it's greater than 3 characters. To get around this, we set a custom stage name per deployment environment using the stage variable. 