### PR TITLE
Add env files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.env
+
 # package directories
 node_modules
 jspm_packages


### PR DESCRIPTION
A minimal PR just to add `.env` files to gitignore to prevent accidentally leaking secret