### PR TITLE
New syntax for serverless package

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -3,7 +3,7 @@ service: example-name # To be replaced
 configValidationMode: error
 
 package:
-  include:
+  patterns:
     - src/
 
 custom:


### PR DESCRIPTION
Update serverless syntax to match with updated document:

https://www.serverless.com/framework/docs/providers/aws/guide/packaging#package-configuration