### PR TITLE
Add jest configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
     testEnvironment: 'node',
+    setupFiles: ['./tests/__config__/jest-env.js'],
     transform: {
         '^.+\\.m?[tj]sx?$': [
             'ts-jest',

--- a/tests/__config__/jest-env.js
+++ b/tests/__config__/jest-env.js
@@ -1,0 +1,1 @@
+process.env.YOUR_ENV_VAR = 'environment-variable';

--- a/tests/example-tests.test.ts
+++ b/tests/example-tests.test.ts
@@ -1,5 +1,7 @@
 import { simpleObject } from './__data__/example-data';
 
+const YOUR_ENV_VAR = process.env.YOUR_ENV_VAR;
+
 describe('Passing tests', () => {
     test('Passing test', () => {
         expect(1).toBeTruthy();
@@ -13,5 +15,11 @@ describe('Passing tests', () => {
 describe('Simple object tests', () => {
     test('Object has correct name', () => {
         expect(simpleObject.name).toEqual('Test Object');
+    });
+});
+
+describe('Env config tests', () => {
+    test('Env config is set correctly', () => {
+        expect(YOUR_ENV_VAR).toEqual('environment-variable');
     });
 });


### PR DESCRIPTION
While writing tests that involve some environment variables, I found out that our template does not support this.

This PR aims to add an example of how to config environment variables while doing unit testing.