### PR TITLE
Update & enable source-map for lambda

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "base",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "source-map-support": "^0.5.21"
-      },
       "devDependencies": {
         "@aligent/serverless-conventions": "^0.4.0",
         "@tsconfig/node18-strictest": "^1.0.0",
@@ -2793,7 +2790,8 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
@@ -8673,6 +8671,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8681,6 +8680,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -12087,7 +12087,8 @@
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "3.3.0",
@@ -16609,12 +16610,14 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "lint": "eslint . --ext .ts",
     "format": "prettier --write ."
   },
-  "dependencies": {
-    "source-map-support": "^0.5.21"
-  },
   "devDependencies": {
     "@aligent/serverless-conventions": "^0.4.0",
     "@tsconfig/node18-strictest": "^1.0.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -10,13 +10,14 @@ custom:
   esbuild:
     bundle: true
     minify: true
+    sourcemap: true
     exclude:
       - '@aws-sdk'
 
 plugins:
+  - '@aligent/serverless-conventions'
   - serverless-esbuild
   - serverless-step-functions
-  - '@aligent/serverless-conventions'
 
 provider:
   name: aws
@@ -24,6 +25,8 @@ provider:
   stage: ${opt:stage, 'dev'}
   region: ${opt:region, 'ap-southeast-2'}
   memorySize: 192 #mb (default for all)
+  environment:
+    NODE_OPTIONS: --enable-source-maps
   # iam:
   #   role:
   #     statements:

--- a/src/hello.ts
+++ b/src/hello.ts
@@ -1,5 +1,3 @@
-import 'source-map-support/register';
-
 // AWSLambda.Handler is provides very generic typing
 // for handler functions. Specific argument and output
 // types can be supplied using generic arguments
@@ -9,7 +7,7 @@ export const handler: AWSLambda.Handler = async (event, context) => {
     console.log('Hello');
     // Cloudwatch logs display objects more cleanly if
     // they are sent as JSON strings
-    console.log('Lambda event: ', JSON.stringify(event))
-    console.log('Lambda context: ', JSON.stringify(context))
+    console.log('Lambda event: ', JSON.stringify(event));
+    console.log('Lambda context: ', JSON.stringify(context));
     return {};
 };

--- a/src/world.ts
+++ b/src/world.ts
@@ -1,5 +1,3 @@
-import 'source-map-support/register';
-
 // AWSLambda.Handler is provides very generic typing
 // for handler functions. Specific argument and output
 // types can be supplied using generic arguments
@@ -9,7 +7,7 @@ export const handler: AWSLambda.Handler = async (event, context) => {
     console.log('World');
     // Cloudwatch logs display objects more cleanly if
     // they are sent as JSON strings
-    console.log('Lambda event: ', JSON.stringify(event))
-    console.log('Lambda context: ', JSON.stringify(context))
+    console.log('Lambda event: ', JSON.stringify(event));
+    console.log('Lambda context: ', JSON.stringify(context));
     return {};
 };


### PR DESCRIPTION
Since Node12x, `source-map-support` package is no longer required as Node 12.12.0 introduced the `--enable-source-maps` flag. (unless we're using the `vm` module, as `--enable-source-maps` does not work with vm.runInThisContext).

I personally think we won't ever use that `vm` module so we can just use the native source map support from Node.

This PR address 3 things:
1. Enable source map when bundle with `esbuild`
2. Enable source map support in Lambda environment
3. Remove unnecessary `source-map-support` package.