### PR TITLE
Feature/micro 78 use plain ts file for modules

### DIFF
--- a/src/hello.ts
+++ b/src/hello.ts
@@ -1,10 +1,17 @@
-// AWSLambda.Handler is provides very generic typing
+// Import a type module defined in `./types/{module-name}/index.d.ts`
+import type { Hello } from 'greetings';
+
+// You can deconstruct modules to import a specific type
+// AWSLambda.Handler provides generic typing
 // for handler functions. Specific argument and output
 // types can be supplied using generic arguments
-// e.g. AWSLambda.Handler<string, object>, and/or using
+// e.g. AWSLambda.Handler<string, object>, or you can use
 // event-specific handler types e.g. AWSLambda.S3Handler
-export const handler: AWSLambda.Handler = async (event, context) => {
-    console.log('Hello');
+import type { Handler } from 'aws-lambda/handler';
+
+export const handler: Handler = async (event, context) => {
+    const message: Hello = 'Hello';
+    console.log(message);
     // Cloudwatch logs display objects more cleanly if
     // they are sent as JSON strings
     console.log('Lambda event: ', JSON.stringify(event));

--- a/src/world.ts
+++ b/src/world.ts
@@ -1,10 +1,17 @@
-// AWSLambda.Handler is provides very generic typing
+// Import a type module defined in `./types/{module-name}/index.d.ts`
+import type { World } from 'greetings';
+
+// You can deconstruct modules to import a specific type
+// AWSLambda.Handler provides generic typing
 // for handler functions. Specific argument and output
 // types can be supplied using generic arguments
-// e.g. AWSLambda.Handler<string, object>, and/or using
+// e.g. AWSLambda.Handler<string, object>, or you can use
 // event-specific handler types e.g. AWSLambda.S3Handler
-export const handler: AWSLambda.Handler = async (event, context) => {
-    console.log('World');
+import type { Handler } from 'aws-lambda/handler';
+
+export const handler: Handler = async (event, context) => {
+    const message: World = 'World';
+    console.log(message);
     // Cloudwatch logs display objects more cleanly if
     // they are sent as JSON strings
     console.log('Lambda event: ', JSON.stringify(event));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,12 +9,12 @@
         "noPropertyAccessFromIndexSignature": false,
         "outDir": "lib",
         "typeRoots": [
-            "./types",
             "./node_modules/@types"
         ],
         "ignoreDeprecations": "5.0"
     },
     "include": [
+        "./types/**/*.ts",
         "./src/**/*.ts",
         "./tests/**/*.ts"
     ],
@@ -24,6 +24,5 @@
         ".build/**/*",
         "_warmup/**/*",
         ".vscode/**/*",
-        "types"
     ]
 }

--- a/types/greetings.ts
+++ b/types/greetings.ts
@@ -1,0 +1,4 @@
+declare module 'greetings' {
+    type Hello = 'Hello';
+    type World = 'World';
+}


### PR DESCRIPTION
Custom internal declarations like this aren't really what `.d.ts` files are for, and typescript was skipping any correctness checks for them due to the `skipLibCheck` setting in `node18-strictest.tsconfig`.

This change includes the root `types` folder in typescript scope so it can be imported and used during development, and typescript will throw errors correctly.

I've also added an example module declaration and usage. I've enjoyed the developer experience of using modules for types used across a system (typically to define the shape of an external system's entities, payloads etc.), but after reading the typescript docs I'm not sure this is the 'correct' way of declaring such types.

Another option is to define a shortcut to the types folder in tsconfig with `paths` and then import via relative path (e.g. `import * as ModuleName from '@/types/module-name`.
@kai-nguyen-aligent has used this approach in the monorepo template, we should settle on one of the two for consistency.