### PR TITLE
Run typescript without emitting to check types in PR pipeline

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -10,6 +10,7 @@ definitions:
         script:
           - npm ci
           - npm run lint
+          - npm run check-types
           - npm run test
     - step: &push-serverless
         name: 'Deploy service'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "jest --coverage",
     "lint": "eslint . --ext .ts",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "check-types": "tsc --noEmit"
   },
   "devDependencies": {
     "@aligent/serverless-conventions": "^0.4.0",


### PR DESCRIPTION
It's easy to miss a typescript error in VSCode because the typescript extension only shows errors for files you have open. Running `tsc --noEmit` will attempt to compile all typescript code without actually producing any files, and generate errors where it encounters invalid typescript as a result.

I think we should have this as another check in our build process for pull requests.