### PR TITLE
chore: Bump version of esbuild to 1.46.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint-config-prettier": "^8.8.0",
         "prettier": "3.0.0",
         "serverless": "^3.33.0",
-        "serverless-esbuild": "^1.45.1",
+        "serverless-esbuild": "^1.46.0",
         "serverless-step-functions": "^3.14.0",
         "typescript": "^5.1.6",
         "vitest": "^0.33.0"
@@ -6996,9 +6996,9 @@
       }
     },
     "node_modules/serverless-esbuild": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/serverless-esbuild/-/serverless-esbuild-1.45.1.tgz",
-      "integrity": "sha512-vPb9R7MoecOv8kdI41BLvYuB5vxBDNKQfGacIuJbmMO25uQHEgyLk27ryb+8XAxmMpb5FuI6/eUZmCK2kRQZZA==",
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/serverless-esbuild/-/serverless-esbuild-1.46.0.tgz",
+      "integrity": "sha512-fMB6PaxUFI/YBPvO9R8G4GXEpYIkXr0Dmsq+Qswj3umHm3otiR9AiKclA65B93pfqVrDfioOx9pQX76+8cuRIw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint-config-prettier": "^8.8.0",
     "prettier": "3.0.0",
     "serverless": "^3.33.0",
-    "serverless-esbuild": "^1.45.1",
+    "serverless-esbuild": "^1.46.0",
     "serverless-step-functions": "^3.14.0",
     "typescript": "^5.1.6",
     "vitest": "^0.33.0"


### PR DESCRIPTION
This patch removes a warning from the serverless package/build process