### PR TITLE
feat: add pre-commit hook to run tests and code style checks

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -25,10 +25,7 @@ for cmd in "${commands[@]}"; do
 done
 
 # Report overall success or failure
-if [ ${#failures[@]} == 0 ]; then
-  echo -e "\n✅${GREEN} Successfully committed changes ${NO_COLOUR}"
-  exit
-else
+if [ ${#failures[@]} -ne 0 ]; then
   echo -e "\n🚩${RED} Couldn't commit changes dues to the following errors: ${NO_COLOUR}"
 
   for report in "${failures[@]}"; do

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Script adapted from https://github.com/kaczor6418/git-hooks-example/blob/master/git-hooks/pre-commit
+# Define colours for nicer CLI output
+RED="\033[1;31m"
+GREEN="\033[1;32m"
+NO_COLOUR="\033[0m"
+
+echo -e "${GREEN} Executing git hook $0 $@ ${NO_COLOUR}"
+
+commands=("npm run lint" "npm run format" "npm run check-types" "npm run test")
+failures=()
+
+# Loop over commands, execute and push failure message if we see one
+for cmd in "${commands[@]}"; do
+  $cmd
+  exit_code=$?
+
+  if [ "$exit_code" -eq 1 ]; then
+    failures+=("✖ Command ${RED}'${cmd}'${NO_COLOUR} failed with exit code ${exit_code} - see CLI output for errors")
+  elif [ "$exit_code" -eq 127 ]; then
+    failures+=("✖ Command ${RED}'${cmd}'${NO_COLOUR} failed with exit code ${exit_code} - check that the script exists in package.json")
+  elif [ "$exit_code" -ne 0 ]; then
+    failures+=("✖ Command ${RED}'${cmd}'${NO_COLOUR} failed with unexpected exit code ${exit_code}")
+  fi
+done
+
+# Report overall success or failure
+if [ ${#failures[@]} == 0 ]; then
+  echo -e "\n✅${GREEN} Successfully committed changes ${NO_COLOUR}"
+  exit
+else
+  echo -e "\n🚩${RED} Couldn't commit changes dues to the following errors: ${NO_COLOUR}"
+
+  for report in "${failures[@]}"; do
+    echo -e $report;
+  done
+
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "scripts": {
     "test": "vitest run --coverage",
     "lint": "eslint --color . --ext .ts",
-    "format": "prettier --write .",
-    "check-types": "tsc --pretty --noEmit"
+    "lint:fix": "eslint --color --fix . --ext .ts",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write .",
+    "check-types": "tsc --pretty --noEmit",
+    "prepare": "git config core.hooksPath '.git-hooks'"
   },
   "devDependencies": {
     "@aligent/serverless-conventions": "^0.4.0",


### PR DESCRIPTION
On `npm install` or `npm ci` the prepare script will configure git to look in `.git-hooks` for commit workflow hooks.

Included is a hook for `pre-commit` which runs eslint, prettier, typescript, and vitest on the repository and prevents committing if errors are encountered.

I have also split lint and format scripts in to standard (reporting only, no writing) and fix versions (will modify files - for manual use)