### PR TITLE
fix: prepare script doesn't attempt to configure non-existing git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "check-types": "tsc --pretty --noEmit",
-    "prepare": "git config core.hooksPath '.git-hooks'"
+    "prepare": "[ -d .git ] && git config core.hooksPath '.git-hooks' || true"
   },
   "devDependencies": {
     "@aligent/serverless-conventions": "^0.4.0",


### PR DESCRIPTION
This makes it possible to avoid having git hooks set up, but I think it's better than forcing people to set up a git repo just to npm ci.