### PR TITLE
Remove git branch track main

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -28,7 +28,6 @@ jobs:
       # The next 2 lines are needed for nx affected to work when CI is running on a PR
       - uses: nrwl/nx-set-shas@v4
       - run: git fetch
-      # - run: git branch --track main origin/main
       - run: npx nx affected -t lint, test, build --parallel=3 --base=origin/main
       - run: npx nx g rm test-lib
       - run: npx nx g rm test-app


### PR DESCRIPTION
This PR completely removes `git branch --track main origin/main` as it's not necessary anymore.