### PR TITLE
MICRO-349: Exclude types folder from test coverage

### DIFF
--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -23,7 +23,7 @@ export const viteBaseConfig = defineConfig({
         environment: 'node',
         coverage: {
             reporter: ['text', 'html'],
-            exclude: ['node_modules/'],
+            exclude: ['node_modules/', '**/types'],
             all: true,
             branches: 80,
             functions: 80,


### PR DESCRIPTION
Since we switched to v8 coverage, vitest complains about our types files:

![image](https://github.com/aligent/serverless-aws-nodejs-service-template/assets/108910975/84eeb5fa-ce00-48fa-96a6-e3b9503bcd2f)

This PR exclude all the `types` folder in vitest coverage report to prevent this issue.