### PR TITLE
chore: Remove override of module resolution

### DIFF
--- a/tools/serverless-plugin/tsconfig.json
+++ b/tools/serverless-plugin/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "Node16",
         "forceConsistentCasingInFileNames": true,
         "strict": true,
         "noImplicitOverride": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,6 @@
         "rootDir": ".",
         "sourceMap": true,
         "declaration": false,
-        "moduleResolution": "node",
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "importHelpers": true,


### PR DESCRIPTION
The tsconfig being extended in tsconfig.base.json already specifies "moduleResolution": "node16"

"moduleResolution": "node" is for earlier versions of NodeJS

This is being picked up as an error in service tsconfigs that extend tsconfig.base.json: `Option 'moduleResolution' must be set to 'Node16' (or left unspecified) when option 'module' is set to 'Node16'.`