### PR TITLE
Chore: Allow unused vars in rest object spreading or prefixed with uderscore

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,13 @@
                         "bundledDependencies": false,
                         "packageDir": "./"
                     }
+                ],
+                "@typescript-eslint/no-unused-vars": [
+                    "error",
+                    {
+                        "argsIgnorePattern": "^_",
+                        "ignoreRestSiblings": true
+                    }
                 ]
             }
         },


### PR DESCRIPTION
It's often useful to be able to discard properties from an object using `{ prop, ...rest } = obj` syntax, or mark unused function arguments with `_` prefix. This change modifies the `no-unused-vars` linting rule to allow both.