### PR TITLE
Feature: Support AWS StepFunctions Fail steps

### DIFF
--- a/tools/serverless-plugin/src/generators/service/notification-files/src/lambda/notify-error.ts.template
+++ b/tools/serverless-plugin/src/generators/service/notification-files/src/lambda/notify-error.ts.template
@@ -18,10 +18,7 @@ export const handler: Handler = async (event: NotifyError.InvocationEvent) => {
 
         const resourceName = extractNameFromExecutionArn(executionArn);
         const name = extractNameFromResourceName(resourceName);
-
-        const { errorType, errorMessage } = JSON.parse(
-            cause
-        ) as NotifyError.Cause;
+        const { errorType, errorMessage } = extractErrorDetails(event);
 
         const nextSteps = generateChatbotNextSteps({
             source,

--- a/tools/serverless-plugin/src/generators/service/notification-files/src/utils/aws-formatting.ts.template
+++ b/tools/serverless-plugin/src/generators/service/notification-files/src/utils/aws-formatting.ts.template
@@ -31,6 +31,37 @@ export function extractNameFromResourceName(resourceName: string) {
     return resourceName.split('-').pop() as string;
 }
 
+/**
+ * Extracts the error details from the error detail object
+ * @param {NotifyError.InvocationEvent['detail']} detail - The detail object to extract the error details from
+ * @returns {NotifyError.Cause} The error details
+ */
+export function extractErrorDetails(
+    event: NotifyError.InvocationEvent
+): NotifyError.Cause {
+    const { cause, error } = event.detail;
+
+    try {
+        const { errorType, errorMessage } = JSON.parse(cause);
+        return {
+            errorType,
+            errorMessage,
+        };
+    } catch (err) {
+        // StepFunctions "Fail" steps return the error details in the "cause" field
+        // where as Lambda will include a JSON object in the "cause" field that
+        // contains the error details
+        if (event.source === 'aws.states') {
+            return {
+                errorType: error,
+                errorMessage: cause,
+            };
+        }
+        throw err;
+    }
+}
+
+
 function generateCloudWatchUrl(region: string, logGroupName?: string) {
     const logGroupsUrl = `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#logsV2:log-groups`;
 

--- a/tools/serverless-plugin/src/generators/service/notification-files/tests/aws-formatting.test.ts.template
+++ b/tools/serverless-plugin/src/generators/service/notification-files/tests/aws-formatting.test.ts.template
@@ -79,6 +79,108 @@ describe('extractNameFromResourceName', () => {
     });
 });
 
+
+describe('extractErrorDetails', () => {
+    it('should extract the error details from a valid Lambda event', () => {
+        const event: NotifyError.InvocationEvent = {
+            source: 'aws.lambda',
+            region: 'ap-southeast-2',
+            detail: {
+                cause: JSON.stringify({
+                    errorType: 'ErrorType',
+                    errorMessage: 'ErrorMessage',
+                }),
+                executionArn: 'my-execution-arn',
+                name: 'my-name',
+                status: 'my-status',
+                error: 'my-error',
+            },
+            id: 'my-id',
+            'detail-type': 'my-detail-type',
+            time: 'my-time',
+            resources: ['my-resource'],
+        };
+
+        const result = extractErrorDetails(event);
+
+        expect(result).toEqual({
+            errorType: 'ErrorType',
+            errorMessage: 'ErrorMessage',
+        });
+    });
+
+    it('should extract the error details from a valid StepFunctions event', () => {
+        const event: NotifyError.InvocationEvent = {
+            source: 'aws.states',
+            region: 'ap-southeast-2',
+            detail: {
+                cause: 'my-cause',
+                executionArn: 'my-execution-arn',
+                name: 'my-name',
+                status: 'my-status',
+                error: 'my-error',
+            },
+            id: 'my-id',
+            'detail-type': 'my-detail-type',
+            time: 'my-time',
+            resources: ['my-resource'],
+        };
+
+        const result = extractErrorDetails(event);
+
+        expect(result).toEqual({
+            errorType: 'my-error',
+            errorMessage: 'my-cause',
+        });
+    });
+
+    it('should throw an error if the cause is not a valid JSON string and the source is aws.lambda', () => {
+        const event: NotifyError.InvocationEvent = {
+            source: 'aws.lambda',
+            region: 'ap-southeast-2',
+            detail: {
+                cause: 'invalid-json',
+                executionArn: 'my-execution-arn',
+                name: 'my-name',
+                status: 'my-status',
+                error: 'my-error',
+            },
+            id: 'my-id',
+            'detail-type': 'my-detail-type',
+            time: 'my-time',
+            resources: ['my-resource'],
+        };
+
+        const result = () => extractErrorDetails(event);
+
+        expect(result).toThrowError(
+            'Unexpected token \'i\', "invalid-json" is not valid JSON'
+        );
+    });
+
+    it('should NOT throw an error if the cause is not a valid JSON string and the source is aws.states', () => {
+        const event: NotifyError.InvocationEvent = {
+            source: 'aws.states',
+            region: 'ap-southeast-2',
+            detail: {
+                cause: 'invalid-json',
+                executionArn: 'my-execution-arn',
+                name: 'my-name',
+                status: 'my-status',
+                error: 'my-error',
+            },
+            id: 'my-id',
+            'detail-type': 'my-detail-type',
+            time: 'my-time',
+            resources: ['my-resource'],
+        };
+
+        const result = () => extractErrorDetails(event);
+
+        expect(result).not.toThrowError();
+    });
+});
+
 describe('generateChatbotNextSteps', () => {
     it('should generate a CloudWatch Log Groups URL if source is aws.lambda but logGroupName is missing', () => {
         const input: NotifyError.NextStepsInput = {


### PR DESCRIPTION
Fail steps don't produce a JSON string, rather they just provide the error detail as-is (typically just a message). So we catch that failure and check whether the source is `aws.states` which then prompts us to return the error as-is.