### PR TITLE
Feature/mi 246 retain relative path for bundled handlers

### DIFF
--- a/tools/cdk-service-plugin/src/generators/service/general-files/src/index.ts.template
+++ b/tools/cdk-service-plugin/src/generators/service/general-files/src/index.ts.template
@@ -9,29 +9,12 @@ export interface <%= name.split('-').map(part => part.charAt(0).toUpperCase() + 
 }
 
 /**
- * Resolves a path to infra assets relative to this stack
+ * Entrypoint for the <%= name %> service
  *
- * @param assetPath - The path to the asset.
- * @returns The resolved path.
- */
-export function resolveAssetPath(assetPath: `${'infra/'}${string}`) {
-    return path.resolve(import.meta.dirname, assetPath);
-}
-
-/**
- * Resolves a path to runtime assets relative to this stack
+ * Instantiate in a CDK Application Stage to deploy to AWS.
  *
- * @param assetPath - The path to the asset.
- * @returns The resolved bundled code path.
+ * Use 'resolve' helpers below when referencing lambda handlers, step function files etc.
  */
-export function resolveRuntimeAssetPath(assetPath: `${'runtime/'}${string}${'.ts'}`) {
-    const bundledPath = path.basename(assetPath).replace(path.extname(assetPath), '');
-    return {
-        code: Code.fromAsset(path.resolve(import.meta.dirname, '../dist', bundledPath)),
-        handler: 'index.handler',
-    };
-}
-
 export class <%= name.split('-').map(part => part.charAt(0).toUpperCase() + part.slice(1)).join('') %>Stack extends Stack {
     constructor(scope: Construct, id: typeof SERVICE_NAME | (string & {}), props?: <%= name.split('-').map(part => part.charAt(0).toUpperCase() + part.slice(1)).join('') %>StackProps) {
         super(scope, id, props);
@@ -43,4 +26,40 @@ export class <%= name.split('-').map(part => part.charAt(0).toUpperCase() + part
 
         Tags.of(this).add('SERVICE', id);
     }
+}
+
+/**
+ * Resolves a path to infra assets relative to this stack
+ *
+ * @param assetPath - The path to the asset.
+ * @returns The resolved path.
+ */
+export function resolveAssetPath(assetPath: `${'infra/'}${string}`) {
+    return path.resolve(import.meta.dirname, assetPath);
+}
+
+/**
+ * Return an object with the default bundled code asset and
+ * handler property for use with the NodejsFunction construct.
+ *
+ * @example
+ * ```ts
+ * new NodejsFunction(this, 'FetchData', {
+ *     ...resolveLambdaHandler('runtime/handlers/fetch-data.ts'),
+ * });
+ * ```
+ *
+ * @param assetPath - The path to the typescript handler file.
+ * @returns The resolved bundled code path and handler name.
+ */
+export function resolveLambdaHandler(assetPath: `${'runtime/handlers/'}${string}${'.ts'}`) {
+    // Replace 'runtime/handlers/' with '..dist/' and remove the file extension
+    const bundledPath = assetPath.replace(
+        /^runtime\/handlers\/(?<path>.*)\.ts$/,
+        '../dist/$<path>'
+    );
+    return {
+        code: Code.fromAsset(path.resolve(import.meta.dirname, bundledPath)),
+        handler: 'index.handler',
+    };
 }

--- a/tools/cdk-service-plugin/src/generators/service/general-files/vite.config.mjs.template
+++ b/tools/cdk-service-plugin/src/generators/service/general-files/vite.config.mjs.template
@@ -6,9 +6,14 @@ import { viteBaseConfig } from '../../vite.config.base.mjs';
 const HANDLERS_PATH = 'src/runtime/handlers';
 
 export default defineConfig(configEnv => {
-    const handlers = fg.sync(`${resolve(import.meta.dirname, HANDLERS_PATH)}/**/*.ts`);
+    const basePath = resolve(import.meta.dirname, HANDLERS_PATH);
+    const handlers = fg.sync(`${basePath}/**/*.ts`);
     const input = Object.fromEntries(
-        handlers.map(handler => [basename(handler, extname(handler)), handler])
+        handlers.map(handler => {
+            const bundledPath = handler.replace(`${basePath}/`, '');
+            const entryName = bundledPath.replace(extname(bundledPath), '');
+            return [entryName, handler];
+        })
     );
 
     return mergeConfig(


### PR DESCRIPTION
I'm not sure we'll need this but I think it's cleaner than expecting everything to be dumped in dist, especially when resolving the paths within a service.

Optionally we can also keep the `/handlers/` folder but I don't see us bundling non-lambda code..

I've also moved the resolver functions below the service stack as that's the most important part of a service.