### PR TITLE
MI-262: (fix) ensure example service instantiation works

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ class ApplicationStage extends Stage {
     Tags.of(this).add('STAGE', id);
 
     // Instantiate service stacks here as required..
-    new YourServiceStack(scope, 'your-service-name', {
+    new YourServiceStack(this, 'your-service-name', {
       ...props,
       description: 'Your service description',
     });


### PR DESCRIPTION
Passing `scope` means the service stacks don't inherit things like the stage tag.