### PR TITLE
MI-259: Fix step 2 of setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ A template for developing a suite of AWS microservices using [AWS CDK](https://d
 
    Example: `@aligent-int/integrations`
 
-2. Install the template and validate it's passing code standards
+2. Install the template, then validate all code standard tests are passing
 
    ```bash
-   nvm use && yarn install && yarn audit
+   nvm use && yarn install
+   yarn audit
    ```
 
 3. (Optional) Commit the initial state of the template. This ensures subsequent changes are easy to review, rather than getting lost in the template boilerplate


### PR DESCRIPTION
Straightforward documentation change to avoid an error caused by running all three commands in one.